### PR TITLE
docs: add templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,59 @@
+---
+name: 🐛 Bug Report
+about: For things that aren't working as expected 🤔.
+labels: bug 🐞
+---
+
+<!--
+Please search to see whether an issue exists for the bug you encountered.
+If you find a closed issue that seems close to what you’re experiencing, include a link to the original issue here.
+-->
+
+### Affected modules
+
+<!-- List the affected modules -->
+
+*
+
+### Terraform CLI and Terraform provider versions
+
+<!-- Run `terraform -v` to show the Terraform core version and provider versions -->
+* Terraform version:
+* Provider version:
+
+### Terraform output
+
+<!-- Please attach a .txt file containing the standard Terraform output -->
+
+### Debug output
+
+<!--
+Follow these steps if you need to enable trace logging to help with debugging:
+
+1. Run export TF_LOG=trace
+2. Run export TF_LOG_PATH=/tmp/trace-log.txt
+3. Reproduce the issue
+4. Attach the trace-log.txt file to the issue
+-->
+
+### Expected behavior
+
+<!-- What should have happened? -->
+
+### Actual behavior
+
+<!-- What actually happened? -->
+
+### Steps to reproduce (including links and screen captures)
+
+<!-- List the steps required to reproduce the issue. -->
+
+1. Run `terraform apply`
+
+### Anything else
+
+<!-- Include anything that will give us more context about the issue. -->
+
+---
+
+By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/terraform-ibm-modules/documentation/blob/main/CODE_OF_CONDUCT.md)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: 🚀 Feature request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+### Description
+
+<!--- Include a clear and concise description of your feature request --->
+
+### New or affected modules
+
+<!--
+Include the name of the module or repo that would be affected.
+Or indicate that you think this would be a new module.
+-->
+
+---
+
+By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/terraform-ibm-modules/documentation/blob/main/CODE_OF_CONDUCT.md)


### PR DESCRIPTION
### Description

Have to duplicate the bug and feature templates to get them to show up. From the GH docs:

>  If a repository has any files in its own `.github/ISSUE_TEMPLATE` folder... none of the contents of the default `.github/ISSUE_TEMPLATE` folder will be used.

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [x] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
